### PR TITLE
Changed toSql() to output lowercase table names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ function searchInRow(row, search, fields, isAdvanced = false) {
 }
 
 function toSql(fileName, row) {
-  let tableName = `${fileName}_dbc`;
+  let tableName = `${fileName}_dbc`.toLowerCase();
   let values = Object.values(row).map(v => typeof v === "string" ? `"${v}"` : v);
   let keys = Object.keys(row).map(v => "`" + v + "`");
   return `INSERT IGNORE INTO ${tableName} (${keys})\n VALUES (${values});`;


### PR DESCRIPTION
Currently, `toSql()` writes table names according to the dbc file name, which can contain uppercase letters that can cause errors (see [this failed CI run on one of my PRs](https://github.com/azerothcore/azerothcore-wotlk/runs/2433230044)).
Since table names are all lowercase, this PR fixes the function to output table names in lowercase.