### PR TITLE
refactor(spell): Rename spell.dbc fields to acore equivalent

### DIFF
--- a/src/schemas/azerothcore/spell.json
+++ b/src/schemas/azerothcore/spell.json
@@ -916,15 +916,15 @@
     "type": "int"
   },
   {
-    "name": "Field227",
+    "name": "EffectBonusMultiplier_1",
     "type": "float"
   },
   {
-    "name": "Field228",
+    "name": "EffectBonusMultiplier_2",
     "type": "float"
   },
   {
-    "name": "Field229",
+    "name": "EffectBonusMultiplier_3",
     "type": "float"
   },
   {


### PR DESCRIPTION
## Proposed Changes
Because of a change in the database structure of the `spell_dbc` table in AzerothCore (https://github.com/azerothcore/azerothcore-wotlk/pull/10633) some field names need to be updated in order to produce correct sql queries.

Following field names changed:
`Field227` to `EffectBonusMultiplier_1`
`Field228` to `EffectBonusMultiplier_2`
`Field229` to `EffectBonusMultiplier_3`